### PR TITLE
Fix slice unit test

### DIFF
--- a/test/circular_buffer_test.exs
+++ b/test/circular_buffer_test.exs
@@ -131,7 +131,7 @@ defmodule CircularBufferTest do
     assert Enum.slice(cb, 6, 5) == []
     assert Enum.slice(cb, 6, 0) == []
     assert Enum.slice(cb, -6, 0) == []
-    assert Enum.slice(cb, -6, 5) == []
+    assert Enum.slice(cb, -6, 5) == [1, 2, 3, 4, 5]
     assert Enum.slice(cb, -2, 5) == [4, 5]
     assert Enum.slice(cb, -3, 1) == [3]
 


### PR DESCRIPTION
This fixes the unit test so that it matches the result of `Enum.slice`
on a regular list.

```elixir
iex> Enum.slice([1, 2, 3, 4, 5], -6, 5)
[1, 2, 3, 4, 5]
```
