### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # CircularBuffer
 
 [![Hex version](https://img.shields.io/hexpm/v/circular_buffer.svg "Hex version")](https://hex.pm/packages/circular_buffer)
-[![API docs](https://img.shields.io/hexpm/v/circular_buffer.svg?label=hexdocs "API docs")](https://hexdocs.pm/circular_buffer/CircularBuffer.html)
+[![API docs](https://img.shields.io/hexpm/v/circular_buffer.svg?label=hexdocs "API docs")](https://circular-buffer.hexdocs.pm/CircularBuffer.html)
 [![CI](https://github.com/elixir-toniq/circular_buffer/actions/workflows/elixir.yml/badge.svg)](https://github.com/elixir-toniq/circular_buffer/actions/workflows/elixir.yml)
 [![REUSE status](https://api.reuse.software/badge/github.com/elixir-toniq/circular_buffer)](https://api.reuse.software/info/github.com/elixir-toniq/circular_buffer)
 

--- a/lib/circular_buffer.ex
+++ b/lib/circular_buffer.ex
@@ -19,8 +19,8 @@ defmodule CircularBuffer do
   of operations.
 
   CircularBuffer implements both the
-  [`Enumerable`](https://hexdocs.pm/elixir/Enumerable.html) and
-  [`Collectable`](https://hexdocs.pm/elixir/Collectable.html) protocols, so code
+  [`Enumerable`](https://elixir.hexdocs.pm/Enumerable.html) and
+  [`Collectable`](https://elixir.hexdocs.pm/Collectable.html) protocols, so code
   like the following works:
 
       iex> cb = Enum.into([1, 2, 3, 4], CircularBuffer.new(3))


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://circular-buffer.hexdocs.pm/CircularBuffer.html): Status 404
❌ Verification failed for https://elixir.hexdocs.pm/Enumerable.html): Status 404
❌ Verification failed for https://elixir.hexdocs.pm/Collectable.html): Status 404
⚠️ Verification finished: 0 success, 3 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>